### PR TITLE
add Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This file contains the changelog for the BasicTypes.jl package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+## [Unreleased]
+
+## [1.0.0] - 2025-01-23
+Initial release of the BasicTypes.jl package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## [1.0.0] - 2025-01-23
 Initial release of the BasicTypes.jl package.
+
+### Added
+- Added the `Optional{T}` type alias, which is a union of `T`, `NotProvided`, and `NotSimulated`. This supersedes the `Maybe{T}` originally used in SatelliteSimulationToolkit.jl

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -13,7 +13,7 @@ include("types.jl")
 export ExtraOutput, NotSimulated, NotProvided
 
 include("type_aliases.jl")
-export UnitfulAngleQuantity, ValidAngle, ValidDistance, PS, Point, Point2D, Point3D, Deg, Rad, Met, Len
+export UnitfulAngleQuantity, ValidAngle, ValidDistance, PS, Point, Point2D, Point3D, Deg, Rad, Met, Len, Optional
 
 include("constants.jl")
 

--- a/src/type_aliases.jl
+++ b/src/type_aliases.jl
@@ -1,3 +1,5 @@
+const Optional{T} = Union{T, NotProvided, NotSimulated}
+
 # helper type alias, taken from CoordRefSystems.jl
 const Len{T} = Quantity{T,u"𝐋"}
 const Met{T} = Quantity{T,u"𝐋",typeof(m)}


### PR DESCRIPTION
Add the Optional UnionAll type, which behave similarly (and should replace) the `Maybe{T}` type from SatelliteSimulationToolkit