### PR TITLE
modify to_unit functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,9 @@ concurrency:
   # Cancel intermediate builds: only if it is a pull request build.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+permissions:
+  actions: write
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,11 @@ Initial release of the BasicTypes.jl package.
 
 ### Added
 - Added the `Optional{T}` type alias, which is a union of `T`, `NotProvided`, and `NotSimulated`. This supersedes the `Maybe{T}` originally used in SatelliteSimulationToolkit.jl
+- A function `to_length` is now defined and export to convert and `ValidDistance` value into a `Unitful.Quantity` with the specified unit. `to_meters` is internally using `to_length` fixing `u"m"` as unit.
+
+### Changed
+- Compared to v0.1.0 of ReferenceViews.jl, the `to_degrees`, `to_radians` and `to_meters` functions now return Unitful quantitites (floating point) rather than unitless numbers.
+  - The `to_radians` and `to_degrees` functions now accept a `RoundingMode` as second argument (instead of as a kwarg). When called with a single argument, the function simply convert the input number without performing angular wrapping.
+
+### Removed
+- Compared to v0.1.0 of ReferenceViews.jl, `to_degrees`, `to_radians` and `to_meters` no longer have methods that accept non-scalar values as input.

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -18,6 +18,6 @@ export UnitfulAngleQuantity, ValidAngle, ValidDistance, PS, Point, Point2D, Poin
 include("constants.jl")
 
 include("functions.jl")
-export to_meters, to_radians, to_degrees, terminal_logger, progress_logger
+export to_length, to_meters, to_radians, to_degrees, terminal_logger, progress_logger
 
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -9,6 +9,8 @@ Take one scalar value representing an angle and convert it to floating point Uni
 
 The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
 
+The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_radians, rounding)`.
+
 See also: [`to_degrees`](@ref), [`to_length`](@ref), [`to_meters`](@ref)
 """
 to_radians(x::Real) = deg2rad(x) * rad
@@ -17,6 +19,7 @@ to_radians(x::UnitfulAngleQuantity) = uconvert(rad, float(x))
 """
     to_degrees(x::ValidAngle)
     to_degrees(x::ValidAngle, rounding::RoundingMode)
+    to_degrees(rounding::RoundingMode)
 
 Take one scalar valid angle and convert it to floating point Unitful quantities with degree (`°`) units.
 
@@ -24,6 +27,8 @@ Take one scalar valid angle and convert it to floating point Unitful quantities 
     The input angles provided as unitless numbers are treated as degrees.
 
 The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
+
+The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_degrees, rounding)`.
 
 See also: [`to_radians`](@ref), [`to_length`](@ref), [`to_meters`](@ref)
 """
@@ -35,15 +40,32 @@ for fname in (:to_radians, :to_degrees)
     # Function that does the rounding
     eval(:($fname(x::ValidAngle, rounding::RoundingMode) = rem($fname(x), $fname(360°), rounding)))
     # Function that takes the rounding-mode and returns a function that applies the specified rounding
-    eval(:($fname(rounding::RoundingMode) = x -> $fname(x, rounding)))
+    eval(:($fname(rounding::RoundingMode) = Base.Fix2($fname, rounding)))
 end
 
 ## Lengths
 
+"""
+    to_length(unit::LengthUnit, x::ValidDistance)
+    to_length(unit::LengthUnit)
+
+Take one scalar value representing a length and convert it to floating point Unitful quantities with the specified `LengthUnit` `unit`.
+
+The single-argument method taking a single `LengthUnit` argument is equivalent to `Base.Fix1(to_length, unit)`.
+
+See also: [`to_meters`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
+"""
 to_length(unit::LengthUnit, x::Len) = uconvert(unit, float(x))
 to_length(unit::LengthUnit, x::Real) = to_length(unit, float(x) * u"m")
-to_length(unit::LengthUnit) = x -> to_length(unit, x)
+to_length(unit::LengthUnit) = Base.Fix1(to_length, unit)
 
+"""
+    to_meters(x::ValidDistance)
+
+Take one scalar value representing a length and convert it to floating point Unitful quantities with the `m` unit.
+
+See also: [`to_length`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
+"""
 to_meters(x::ValidDistance) = to_length(u"m")(x)
 
 # Logger

--- a/src/type_aliases.jl
+++ b/src/type_aliases.jl
@@ -7,8 +7,19 @@ const Deg{T} = Quantity{T,NoDims,typeof(°)}
 const Rad{T} = Quantity{T,NoDims,typeof(rad)}
 
 ## Angle Types
+const LengthUnit = Unitful.Units{<:Any, u"𝐋", nothing}
 const UnitfulAngleQuantity = Union{Deg, Rad}
+"""
+    const ValidAngle = Union{UnitfulAngleQuantity, Real}
+
+Union type representing a scalar value that can be interpreted as an angle, which can be either a unitless real number, or a Unitful.Quantity with `u"rad"` or `u"°"` as unit.
+"""
 const ValidAngle = Union{UnitfulAngleQuantity, Real}
+"""
+    const ValidDistance = Union{Len, Real}
+
+Union type representing a scalar value that can be interpreted as a distance, which can be either a unitless real number, or a Unitful.Quantity with a valid Length unit.
+"""
 const ValidDistance = Union{Len, Real}
 
 # Type alias for valid point subtypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using TestItemRunner
 end
 
 @testitem "EmptyIterator" begin
-
     for T in (NotSimulated, NotProvided)
         @test_nowarn for i in T()
             error("ASD")
@@ -16,7 +15,6 @@ end
         @test length(T()) == 0
         @test eachindex(T()) == Base.OneTo(0)
     end
-
 end
 
 @testitem "Terminal Logger" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,14 +7,16 @@ using TestItemRunner
 end
 
 @testitem "EmptyIterator" begin
-    @test_nowarn for i in NotSimulated()
-        error("ASD")
+
+    for T in (NotSimulated, NotProvided)
+        @test_nowarn for i in T()
+            error("ASD")
+        end
+        @test collect(T()) == Union{}[]
+        @test length(T()) == 0
+        @test eachindex(T()) == Base.OneTo(0)
     end
 
-    @test collect(NotProvided()) == Union{}[]
-
-    @test length(NotSimulated()) == 0
-    @test eachindex(NotSimulated()) == Base.OneTo(0)
 end
 
 @testitem "Terminal Logger" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,30 +5,6 @@ using TestItemRunner
     Aqua.test_all(BasicTypes) 
     # Aqua.test_ambiguities(BasicTypes)
 end
-@testitem "to_unit functions" begin
-    using BasicTypes.Unitful: rad, ustrip, m
-    # Test vector version of default units
-    @test all(to_radians([π/4, .2, .4rad, 18°]) .≈ [π/4, .2, .4, π/10 ])
-    @test_throws "You can only call" to_radians(1im)
-    @test all(to_degrees(Any[10, (π/2)*rad, .1, 18°]) .≈ [10, 90, .1, 18]) # Any is needed because the Vector is automatically converted to Vector{Float} (in radians)
-    @test_throws "You can only call" to_degrees(1im)
-    @test all(to_meters(Any[1, 2m, 3km]) .≈ [1, 2, 3000])
-    @test_throws "You can only call" to_meters([1, 2m, 3km]) # The vector without specifying Any is transformed in Unitful.Quantity (which is not a valid length)
-
-    @test to_radians(1000°) ≈ deg2rad(-80)
-    @test to_radians(6.5π) ≈ π/2
-    @test to_radians(400°; rounding=RoundDown) ≈ deg2rad(40)
-    @test to_radians(-400°; rounding=RoundToZero) ≈ deg2rad(-40)
-    @test to_radians(6.5π; rounding=RoundDown) ≈ deg2rad(90)
-    @test to_radians(-6.5π; rounding=RoundToZero) ≈ deg2rad(-90)
-    
-    @test to_degrees(1000) ≈ -80
-    @test to_degrees(rad2deg(6.5π)) ≈ 90
-    @test to_degrees(400; rounding=RoundDown) ≈ 40
-    @test to_degrees(-400; rounding=RoundToZero) ≈ -40
-    @test to_degrees(6.5π*rad; rounding=RoundDown) ≈ 90
-    @test to_degrees(-6.5π*rad; rounding=RoundToZero) ≈ -90
-end
 
 @testitem "EmptyIterator" begin
     @test_nowarn for i in NotSimulated()
@@ -39,20 +15,6 @@ end
 
     @test length(NotSimulated()) == 0
     @test eachindex(NotSimulated()) == Base.OneTo(0)
-end
-
-@testitem "Check Angle" begin
-    using BasicTypes: _check_angle_func, _check_angle
-    @test _check_angle_func(deg2rad(23))(-23°)
-    @test !_check_angle_func(deg2rad(23))(-23.1°)
-    @test _check_angle_func(deg2rad(23))(deg2rad(-23))
-    @test !_check_angle_func(deg2rad(23))(deg2rad(-23.1))
-    @test _check_angle_func(23°)(-23°)
-    @test !_check_angle_func(23°)(-23.1°)
-    @test _check_angle_func(23°)(deg2rad(-23))
-    @test !_check_angle_func(23°)(deg2rad(-23.1))
-
-    @test_throws "in radians" _check_angle(6π)
 end
 
 @testitem "Terminal Logger" begin

--- a/test/units.jl
+++ b/test/units.jl
@@ -15,5 +15,5 @@
     @test to_degrees(RoundDown)(6.5π * rad) ≈ 90°
     @test to_degrees(-6.5π * rad, RoundToZero) ≈ -90°
 
-    @test to_meters(10km) ≈ 10000m
+    @test to_meters(10km) ≈ 10000m ≈ to_meters(1e4)
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,0 +1,19 @@
+@testitem "to_unit functions" begin
+    using BasicTypes.Unitful: rad, m
+    # Test vector version of default units
+    @test to_radians(1000°) ≈ 1000°
+    @test 6.5π * rad |> ustrip ∘ to_radians(RoundNearest) ≈ π/2
+    @test to_radians(400, RoundDown) ≈ 40°
+    @test to_radians(RoundToZero)(-400°) ≈ -40°
+    @test to_radians(6.5π * rad, RoundDown) ≈ 90°
+    @test to_radians(-6.5π * rad, RoundToZero) ≈ -90°
+    
+    @test to_degrees(1000, RoundNearest) ≈ -80°
+    @test to_degrees(rad2deg(6.5π)) ≈ 360° * 3 + 90°
+    @test to_degrees(400, RoundDown) ≈ 40°
+    @test to_degrees(-400, RoundToZero) ≈ -40°
+    @test to_degrees(RoundDown)(6.5π * rad) ≈ 90°
+    @test to_degrees(-6.5π * rad, RoundToZero) ≈ -90°
+
+    @test to_meters(10km) ≈ 10000m
+end


### PR DESCRIPTION
This PR changes the behavior of the `to_degrees`, `to_radians` and `to_meters` in the following way compared to their functionality in ReferenceViews.jl v0.1.0:
- They now return Unitful.Quantities rather than unitless numbers.
  - This is a first step towards moving length/angles to Unitful.Quantities in packages of the ecosystem.
- As an effort to simplfy the codebase, the functions above are also not accepting collections as input anymore, favoring an explicit use of `map` in that case without relying on automagic.
- The angular functions (`to_degrees` and `to_radians`) also drop the `rounding` keyword argument in favor of a dual signature: 
  - with a single `ValidAngle` form they simply convert the input to the relevant Unitful.Quantity without performing angular wrapping
  - with a `ValidAngle` as first argument and a `RoundingMode` as second argument, they perform angular wrapping of the angle using `rem` and the specified rounding mode. This is more similar to the actual signature of the `rem` function used for performing the wrapping.
  - With `RoundingMode` as a single argumnet, they return a 1-arg function that calls the 2-arg version applying the specified `RoundingMode`
  - Finally, there is now a `to_length` function which is a generic extension of the `to_meters` concept which takes a length unit as first argument and perform the conversion of the input `ValidDistance` to the Unitful.Quantity of the provided unit.
