### PR TITLE
Add `sa_type` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## [Unreleased]
 
+### Added
+- Added the `sa_type` function, which can be used to create a `StructArray` type providing the eltype and the number of dimensions. This is mostly useful for simplifying creating types of fields which holds `StructArray` elements in struct definitions.
+
 ## [1.8.0] - 2025-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## [Unreleased]
 
+## [1.8.0] - 2025-05-22
+
 ### Added
 
 - Add const NamedTuple `CONSTANTS` with useful physical constants.

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,17 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[weakdeps]
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+
+[extensions]
+StructArraysExt = "StructArrays"
+
 [compat]
 Logging = "1"
 LoggingExtras = "1.1.0"
 StaticArrays = "1.9.10"
+StructArrays = "0.7.1"
 TerminalLoggers = "0.1.7"
 Unitful = "1.22.0"
 julia = "1.11"

--- a/ext/StructArraysExt.jl
+++ b/ext/StructArraysExt.jl
@@ -1,0 +1,18 @@
+module StructArraysExt
+
+using StructArrays: StructArrays, StructArray
+using BasicTypes: BasicTypes, sa_type
+
+function BasicTypes.sa_type(DT::DataType, N::Union{Int,TypeVar}; unwrap=T -> false)
+    # Create the NamedTuple for the StructArray type parameter
+    f = T -> unwrap(T) ? sa_type(T, N) : Array{T,N} # Eventually unwrap like in the StructArray constructor
+    TT = Tuple{map(f, fieldtypes(DT))...}
+    NT = if DT <: Tuple
+        TT
+    else
+        NamedTuple{fieldnames(DT),TT}
+    end
+    return StructArray{DT,N,NT,Int}
+end
+
+end

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -19,7 +19,7 @@ include("constants.jl")
 export CONSTANTS
 
 include("functions.jl")
-export to_length, to_meters, to_radians, to_degrees, terminal_logger, progress_logger, basetype, asdeg, stripdeg, isnotset, fallback
+export to_length, to_meters, to_radians, to_degrees, terminal_logger, progress_logger, basetype, asdeg, stripdeg, isnotset, fallback, sa_type
 
 include("macros.jl")
 export @define_kwargs_defaults, @add_kwargs_defaults, @fallback

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -233,7 +233,7 @@ end
 
 The function supports unwrapping like in the `StructArray` constructor by providing the appropriate function as the `unwrap` keyword argument.
 
-It also supports a `TypeVar` as second argument instead of simply an Int. This is useful for creating complex composite types like in the example below.
+It also supports a `TypeVar` as second argument instead of simply an `Int`. This is useful for creating complex composite types like in the example below.
 
 ```julia
 @kwdef struct InnerField

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,8 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/test/structarrays.jl
+++ b/test/structarrays.jl
@@ -1,0 +1,42 @@
+@testitem "sa_type" begin
+    using StructArrays
+    using BasicTypes
+    using Test
+
+    @testset "Tuple input type" begin
+        DT = Tuple{Int,Complex{Int}}
+        sa_unwrapped = StructArray((1, Complex(i, j)) for i = 1:3, j = 2:4; unwrap=T -> !(T <: Real))
+        sa_wrapped = StructArray((1, Complex(i, j)) for i = 1:3, j = 2:4)
+
+        @test typeof(sa_unwrapped) == sa_type(DT, 2; unwrap=T -> !(T <: Real))
+        @test typeof(sa_wrapped) == sa_type(DT, 2)
+    end
+
+    @test_throws ArgumentError sa_type(Complex, 2)
+
+    @kwdef struct InnerField
+        a::Float64 = rand()
+        b::Complex{Float64} = rand(ComplexF64)
+    end
+
+    @kwdef struct CompositeStruct
+        inner::InnerField = InnerField()
+        int::Int = rand(1:10)
+    end
+
+    struct SAField{N}
+        sa::sa_type(CompositeStruct, N)
+    end
+
+    struct SAFieldUW{N}
+        sa::sa_type(CompositeStruct, N; unwrap=T -> (T <: InnerField))
+    end
+    @testset "Custom Composite type" begin
+        sa_unwrapped = StructArray([CompositeStruct() for i in 1:3, j in 1:2]; unwrap = T -> (T<:InnerField))
+
+        sa_wrapped = StructArray([CompositeStruct() for i in 1:3, j in 1:2])
+
+        @test SAFieldUW(sa_unwrapped) isa SAFieldUW{2}
+        @test SAField(sa_wrapped) isa SAField{2}
+    end
+end


### PR DESCRIPTION
This PR adds the `sa_type` function, which can be used to create a `StructArray` type providing the eltype and the number of dimensions. This is mostly useful for simplifying creating types of fields which holds `StructArray` elements in struct definitions.
