### PR TITLE
Add more unitful helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file contains the changelog for the BasicTypes.jl package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 ## Unreleased
+## [1.12.0] - 2025-06-27
+
+### Added
+- Added two new generic function `enforce_unit` and `enforce_unitless` to converts between compatible units and ensure a return value that has either a unit or not in its type. See the docstrings for more details
 
 ## [1.11.1] - 2025-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 ### Added
 - Added two new generic function `enforce_unit` and `enforce_unitless` to converts between compatible units and ensure a return value that has either a unit or not in its type. See the docstrings for more details
 
+### Deprecated
+- The `to_length` and `to_meters` are now deprecated in favor of direct use of `enforce_unit`. The docstrings as well as their execution will not print a warning. These will be removed in a future breaking release.
+
 ## [1.11.1] - 2025-06-18
 
 ### Fixed

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -5,7 +5,7 @@ using LoggingExtras: LoggingExtras, TeeLogger
 using StaticArrays: StaticArrays, SVector
 using TerminalLoggers: TerminalLoggers, TerminalLogger
 using Unitful: Unitful, °, rad, Quantity, Length, NoDims, m, km, @u_str, 
-    ustrip, uconvert
+    ustrip, uconvert, unit, Units
 
 # Exports from deps
 export °, km, @u_str, ustrip
@@ -16,6 +16,9 @@ export ExtraOutput, NotSimulated, NotProvided, SkipChecks
 include("type_aliases.jl")
 export UnitfulAngleQuantity, ValidAngle, ValidDistance, PS, Point, Point2D, 
     Point3D, Deg, Rad, Met, Len, Optional, NotSet
+
+include("unitful_helpers.jl")
+export enforce_unit, enforce_unitless
 
 include("constants.jl")
 export CONSTANTS

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -36,75 +36,6 @@ end
 """
 function constructor_without_checks end
 
-"""
-    to_radians(x::ValidAngle)
-    to_radians(x::ValidAngle, rounding::RoundingMode)
-
-Take one scalar value representing an angle and convert it to floating point Unitful quantities with radian (`rad`) units.
-
-!!! note
-    The input angles provided as unitless numbers are treated as degrees.
-
-The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
-
-The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_radians, rounding)`.
-
-See also: [`to_degrees`](@ref), [`to_length`](@ref), [`to_meters`](@ref)
-"""
-to_radians(x::Real) = deg2rad(x) * rad
-to_radians(x::UnitfulAngleQuantity) = uconvert(rad, float(x))
-
-"""
-    to_degrees(x::ValidAngle)
-    to_degrees(x::ValidAngle, rounding::RoundingMode)
-    to_degrees(rounding::RoundingMode)
-
-Take one scalar valid angle and convert it to floating point Unitful quantities with degree (`°`) units.
-
-!!! note
-    The input angles provided as unitless numbers are treated as degrees.
-
-The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
-
-The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_degrees, rounding)`.
-
-See also: [`to_radians`](@ref), [`to_length`](@ref), [`to_meters`](@ref)
-"""
-to_degrees(x::Real) = float(x) * °
-to_degrees(x::UnitfulAngleQuantity) = uconvert(°, float(x))
-
-# Do the common methods
-for fname in (:to_radians, :to_degrees)
-    # Function that does the rounding
-    eval(:($fname(x::ValidAngle, rounding::RoundingMode) = rem($fname(x), $fname(360°), rounding)))
-    # Function that takes the rounding-mode and returns a function that applies the specified rounding
-    eval(:($fname(rounding::RoundingMode) = Base.Fix2($fname, rounding)))
-end
-
-## Lengths
-
-"""
-    to_length(unit::LengthUnit, x::ValidDistance)
-    to_length(unit::LengthUnit)
-
-Take one scalar value representing a length and convert it to floating point Unitful quantities with the specified `LengthUnit` `unit`.
-
-The single-argument method taking a single `LengthUnit` argument is equivalent to `Base.Fix1(to_length, unit)`.
-
-See also: [`to_meters`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
-"""
-to_length(unit::LengthUnit, x::Len) = uconvert(unit, float(x))
-to_length(unit::LengthUnit, x::Real) = to_length(unit, float(x) * u"m")
-to_length(unit::LengthUnit) = Base.Fix1(to_length, unit)
-
-"""
-    to_meters(x::ValidDistance)
-
-Take one scalar value representing a length and convert it to floating point Unitful quantities with the `m` unit.
-
-See also: [`to_length`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
-"""
-to_meters(x::ValidDistance) = to_length(u"m")(x)
 
 # Logger
 """
@@ -147,31 +78,6 @@ basetype(t::DataType) = t.name.wrapper
 basetype(t::UnionAll) = basetype(t.body)
 basetype(::T) where T = basetype(T)
 
-"""
-    asdeg(x::Real)
-
-Convert the provided value assumed to be in radians to Unitful degrees.
-
-The [`stripdeg`](@ref) function performs the inverse operation.
-
-```julia
-asdeg(π) ≈ 180.0°
-```
-"""
-asdeg(x::Real) = rad2deg(x) * °
-
-"""
-    stripdeg(x::Deg)
-
-Strip the units from the provided `Deg` field and convert it to radians.
-
-The [`asdeg`](@ref) function performs the inverse operation.
-
-```julia
-stripdeg(180.0°) ≈ π
-```
-"""
-stripdeg(x::Deg) = x |> ustrip |> deg2rad
 
 
 """

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -4,7 +4,7 @@
     
 Takes the provided `value` (supposed to represent a quantity tied to a specific unit) and converts it so that it to the unit provided as `reference`.
 
-!!! note Unit
+!!! note
     The provided `reference` must be a unit compatible with the unit expected from `value`.
 
 In case only `reference` is provided (second signature above), this function simply returns `Base.Fix1(enforce_unit, reference)`.
@@ -24,7 +24,7 @@ In case only `reference` is provided (second signature above), this function sim
 julia> using BasicTypes
 
 julia> enforce_unit(u"m", 2f0 * u"km/h") # Throws are units are not compatible
-ERROR: DimensionError: m and km J^-1 s^-1 are not dimensionally compatible.
+ERROR: DimensionError:
 
 julia> enforce_unit(typeof(1f0u"m"), 1km) # Also converts to Float32 as the provided reference is a Float32 quantity
 1000.0f0 m
@@ -33,7 +33,7 @@ julia> enforce_unit(1f0u"rad", 10°) # Also converts to Float32 as the provided 
 0.17453292f0 rad
 
 julia> enforce_unit(1u"km", 3u"m") # Providing a quantity directly also tries to enforce the precision
-ERROR: InexactError: Int64(3//1000)
+ERROR: InexactError:
 
 julia> enforce_unit(u"km", 3u"m") # This will not enforce precision
 3//1000 km
@@ -160,7 +160,7 @@ end
     to_length(unit::LengthUnit)
 
 !!! warn
-    This function is deprecated now, consider using the more explicit form `enforce_unit(unit, float(x))` instead.
+    This function is deprecated now, consider using the more explicit form `enforce_unit(unit, float(x))` (or `enforce_unit(unit) ∘ float` for the single-argument method) instead.
 
 
 Take one scalar value representing a length and convert it to floating point Unitful quantities with the specified `LengthUnit` `unit`.

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -48,10 +48,16 @@ julia> 1km |> enforce_unit(u"m") ∘ float # Test the method returning a functio
 See also: [`enforce_unitless`](@ref)
 """
 enforce_unit(reference::Units, value::Quantity) = uconvert(reference, value)
-enforce_unit(reference::Type{<:Quantity}, value::Quantity) = convert(reference, value)
+function enforce_unit(reference::Type{<:Quantity}, value::Quantity)
+    (isconcretetype(reference) && isconcretetype(valuetype(reference))) || throw(ArgumentError("The provided Quantity type to use as reference is not concrete"))
+    return convert(reference, value)
+end
 
 # Version that takes a unitless number and returns it 
-enforce_unit(reference::Type{<:Quantity}, value::Number) = return reference(value) # Create the instance directly
+function enforce_unit(reference::Type{<:Quantity}, value::Number)
+    (isconcretetype(reference) && isconcretetype(valuetype(reference))) || throw(ArgumentError("The provided Quantity type to use as reference is not concrete"))
+    return reference(value) # Create the instance directly
+end
 enforce_unit(reference::Units, value::Number) = reference * value
 
 # This is a fallback if one provides a quantity instance directly as reference

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -40,6 +40,9 @@ julia> enforce_unit(u"km", 3u"m") # This will not enforce precision
 
 julia> enforce_unit(u"km", 3) # This will simply apply the desired unit to the provided value
 3 km
+
+julia> 1km |> enforce_unit(u"m") ∘ float # Test the method returning a function
+1000.0 m
 ```
 
 See also: [`enforce_unitless`](@ref)
@@ -68,7 +71,22 @@ This will simply call `ustrip(enforce_unit(reference, value))`.
 
 If only `reference` is provided (second signature above), this function simply returns `Base.Fix1(enforce_unitless, reference)`.
 
-See [`enforce_unit`](@ref) for more details on the supported argument types and examples
+See [`enforce_unit`](@ref) for more details on the supported argument types.
+
+# Examples
+
+```jldoctest
+julia> using BasicTypes
+
+julia> enforce_unitless(1f0u"m", 1km)
+1000.0f0
+
+julia> enforce_unitless(u"m", 1)
+1
+
+julia> 1km |> enforce_unitless(u"m") ∘ float # Test the method returning a function
+1000.0
+```
 """
 enforce_unitless(reference, value) = ustrip(enforce_unit(reference, value))
 enforce_unitless(reference) = Base.Fix1(enforce_unitless, reference)

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -106,3 +106,89 @@ julia> stripdeg(180.0°)
 ```
 """
 stripdeg(x::Deg) = x |> ustrip |> deg2rad
+
+"""
+    to_radians(x::ValidAngle)
+    to_radians(x::ValidAngle, rounding::RoundingMode)
+    to_radians(rounding::RoundingMode)
+
+Take one scalar value representing an angle and convert it to floating point Unitful quantities with radian (`rad`) units.
+
+!!! note
+    The input angles provided as unitless numbers are treated as degrees.
+
+The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
+
+The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_radians, rounding)`.
+
+See also: [`to_degrees`](@ref), [`enforce_unit`](@ref)
+"""
+to_radians(x::Real) = deg2rad(x) * rad
+to_radians(x::UnitfulAngleQuantity) = uconvert(rad, float(x))
+
+"""
+    to_degrees(x::ValidAngle)
+    to_degrees(x::ValidAngle, rounding::RoundingMode)
+    to_degrees(rounding::RoundingMode)
+
+Take one scalar valid angle and convert it to floating point Unitful quantities with degree (`°`) units.
+
+!!! note
+    The input angles provided as unitless numbers are treated as degrees.
+
+The 2-arg method can be used to also wrap (using `rem`) the angle provided as first argument using the rounding mode specified as second argument.
+
+The last method taking a single `RoundingMode` argument is equivalent to `Base.Fix2(to_degrees, rounding)`.
+
+See also: [`to_radians`](@ref), [`enforce_unit`](@ref)
+"""
+to_degrees(value::ValidAngle) = enforce_unit(°, float(value))
+
+# Do the common methods
+for fname in (:to_radians, :to_degrees)
+    # Function that does the rounding
+    eval(:($fname(x::ValidAngle, rounding::RoundingMode) = rem($fname(x), $fname(360°), rounding)))
+    # Function that takes the rounding-mode and returns a function that applies the specified rounding
+    eval(:($fname(rounding::RoundingMode) = Base.Fix2($fname, rounding)))
+end
+
+
+#### Deprecated length functions ####
+
+"""
+    to_length(unit::LengthUnit, x::ValidDistance)
+    to_length(unit::LengthUnit)
+
+!!! warn
+    This function is deprecated now, consider using the more explicit form `enforce_unit(unit, float(x))` instead.
+
+
+Take one scalar value representing a length and convert it to floating point Unitful quantities with the specified `LengthUnit` `unit`.
+
+The single-argument method taking a single `LengthUnit` argument is equivalent to `Base.Fix1(to_length, unit)`.
+
+See also: [`to_meters`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
+"""
+function to_length(unit)
+    @warn "`to_length(unit)` is deprecated, consider using the more explicit form `enforce_unit(unit) ∘ float` instead"
+    return Base.Fix1(to_length, unit)
+end
+function to_length(unit, x::ValidDistance)
+    @warn "`to_length(unit, x)` is deprecated, consider using the more explicit form `enforce_unit(unit, float(x))` instead"
+    return enforce_unit(unit, float(x))
+end
+
+"""
+    to_meters(x::ValidDistance)
+
+!!! warn
+    This function is deprecated now, use directly the new signature `enforce_unit(u"m", x)` instead.
+
+Take one scalar value representing a length and convert it to floating point Unitful quantities with the `m` unit.
+
+See also: [`to_length`](@ref), [`to_radians`](@ref), [`to_degrees`](@ref)
+"""
+function to_meters(x::ValidDistance)
+    @warn "to_meters is deprecated, use the new and more generic `enforce_unit(u\"m\", x)` instead"
+    return enforce_unit(u"m", x)
+end

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -40,9 +40,9 @@ julia> enforce_unit(u"km", 3u"m") # This will not enforce precision
 
 julia> enforce_unit(u"km", 3) # This will simply apply the desired unit to the provided value
 3 km
+```
 
 See also: [`enforce_unitless`](@ref)
-```
 """
 enforce_unit(reference::Units, value::Quantity) = uconvert(reference, value)
 enforce_unit(reference::Type{<:Quantity}, value::Quantity) = convert(reference, value)
@@ -72,3 +72,37 @@ See [`enforce_unit`](@ref) for more details on the supported argument types and 
 """
 enforce_unitless(reference, value) = ustrip(enforce_unit(reference, value))
 enforce_unitless(reference) = Base.Fix1(enforce_unitless, reference)
+
+
+#### Helpers specifically for angles ####
+"""
+    asdeg(x::Real)
+
+Convert the provided value assumed to be in radians to Unitful degrees.
+
+The [`stripdeg`](@ref) function performs the inverse operation.
+
+```jldoctest
+julia> using BasicTypes
+
+julia> asdeg(π)
+180.0°
+```
+"""
+asdeg(x::Real) = rad2deg(x) * °
+
+"""
+    stripdeg(x::Deg)
+
+Strip the units from the provided value (expected to be a `Unitful.Quantity` in degrees) and convert it to radians.
+
+The [`asdeg`](@ref) function performs the inverse operation.
+
+```jldoctest
+julia> using BasicTypes
+
+julia> stripdeg(180.0°)
+3.141592653589793
+```
+"""
+stripdeg(x::Deg) = x |> ustrip |> deg2rad

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -5,7 +5,7 @@
 Takes the provided `value` (supposed to represent a quantity tied to a specific unit) and converts it so that it to the unit provided as `reference`.
 
 !!! note
-    The provided `reference` must be a unit compatible with the unit expected from `value`.
+    The provided `reference` must represent a unit compatible with the unit expected from `value`.
 
 In case only `reference` is provided (second signature above), this function simply returns `Base.Fix1(enforce_unit, reference)`.
 

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -1,0 +1,74 @@
+"""
+    enforce_unit(reference, value)
+    enforce_unit(reference)
+    
+Takes the provided `value` (supposed to represent a quantity tied to a specific unit) and converts it so that it to the unit provided as `reference`.
+
+!!! note Unit
+    The provided `reference` must be a unit compatible with the unit expected from `value`.
+
+In case only `reference` is provided (second signature above), this function simply returns `Base.Fix1(enforce_unit, reference)`.
+
+# Arguments
+- `reference`: The unit to convert `value` to. It can be an instance from one of the following types:
+  - `Unitful.Units`: e.g. u"m".
+  - `Type{<:Quantity}`: e.g. typeof(1u"°").
+  - `Quantity`: e.g. 2f0 * u"m/s".
+
+- `value`: The value to convert. It can be an instance from one of the following types:
+  - `Quantity`: e.g. 2f0 * u"m/s".
+  - `Number`: A unitless number. **NOTE: In this case, the number is simply assumed to already have the right scale and simply returned as a `Quantity` with the provided  `reference` unit.**
+
+# Examples
+```jldoctest
+julia> using BasicTypes
+
+julia> enforce_unit(u"m", 2f0 * u"km/h") # Throws are units are not compatible
+ERROR: DimensionError: m and km J^-1 s^-1 are not dimensionally compatible.
+
+julia> enforce_unit(typeof(1f0u"m"), 1km) # Also converts to Float32 as the provided reference is a Float32 quantity
+1000.0f0 m
+
+julia> enforce_unit(1f0u"rad", 10°) # Also converts to Float32 as the provided reference is a Float32 quantity
+0.17453292f0 rad
+
+julia> enforce_unit(1u"km", 3u"m") # Providing a quantity directly also tries to enforce the precision
+ERROR: InexactError: Int64(3//1000)
+
+julia> enforce_unit(u"km", 3u"m") # This will not enforce precision
+3//1000 km
+
+julia> enforce_unit(u"km", 3) # This will simply apply the desired unit to the provided value
+3 km
+
+See also: [`enforce_unitless`](@ref)
+```
+"""
+enforce_unit(reference::Units, value::Quantity) = uconvert(reference, value)
+enforce_unit(reference::Type{<:Quantity}, value::Quantity) = convert(reference, value)
+
+# Version that takes a unitless number and returns it 
+enforce_unit(reference::Type{<:Quantity}, value::Number) = reference(value) # Create the instance directly
+enforce_unit(reference::Units, value::Number) = reference * value
+
+# This is a fallback if one provides a quantity instance directly as reference
+enforce_unit(reference::Quantity, value::Number) = enforce_unit(typeof(reference), value)
+
+# Function creating a function to enforce a specific unit
+enforce_unit(reference) = Base.Fix1(enforce_unit, reference)
+
+
+# For the unitless version, we first apply the desired unit and then strip the units
+"""
+    enforce_unitless(reference, value)
+    enforce_unitless(reference)
+
+Takes the provided `value` (supposed to represent a quantity tied to a specific unit), converts it to the unit represented by `reference` and then strips the units.
+This will simply call `ustrip(enforce_unit(reference, value))`.
+
+If only `reference` is provided (second signature above), this function simply returns `Base.Fix1(enforce_unitless, reference)`.
+
+See [`enforce_unit`](@ref) for more details on the supported argument types and examples
+"""
+enforce_unitless(reference, value) = ustrip(enforce_unit(reference, value))
+enforce_unitless(reference) = Base.Fix1(enforce_unitless, reference)

--- a/src/unitful_helpers.jl
+++ b/src/unitful_helpers.jl
@@ -51,7 +51,7 @@ enforce_unit(reference::Units, value::Quantity) = uconvert(reference, value)
 enforce_unit(reference::Type{<:Quantity}, value::Quantity) = convert(reference, value)
 
 # Version that takes a unitless number and returns it 
-enforce_unit(reference::Type{<:Quantity}, value::Number) = reference(value) # Create the instance directly
+enforce_unit(reference::Type{<:Quantity}, value::Number) = return reference(value) # Create the instance directly
 enforce_unit(reference::Units, value::Number) = reference * value
 
 # This is a fallback if one provides a quantity instance directly as reference

--- a/test/units.jl
+++ b/test/units.jl
@@ -32,3 +32,13 @@ end
     @test_logs (:warn, r"deprecated") to_length(u"m", 10km)
     @test_logs (:warn, r"deprecated") match_mode=:any to_length(u"m")(10km)
 end
+
+@testitem "enforce_unit" begin
+    using BasicTypes: Deg
+    @test enforce_unit(1u"m", 10km) ≈ 10000u"m"
+    @test enforce_unit(1u"m", 10) ≈ 10u"m"
+
+    # We test the error for non concrete quantities
+    @test_throws ArgumentError enforce_unit(Deg, 10km)
+    @test_throws ArgumentError enforce_unit(Deg{AbstractFloat}, 10)
+end

--- a/test/units.jl
+++ b/test/units.jl
@@ -24,3 +24,11 @@ end
     @test asdeg(π) ≈ 180.0°
     @test stripdeg(180.0°) ≈ π
 end
+
+@testitem "to_meters/to_length deprecation" begin
+    using BasicTypes: to_meters, to_length
+
+    @test_logs (:warn, r"deprecated") to_meters(10km)
+    @test_logs (:warn, r"deprecated") to_length(u"m", 10km)
+    @test_logs (:warn, r"deprecated") match_mode=:any to_length(u"m")(10km)
+end


### PR DESCRIPTION
From the updated changelog:

### Added
- Added two new generic function `enforce_unit` and `enforce_unitless` to converts between compatible units and ensure a return value that has either a unit or not in its type. See the docstrings for more details

### Deprecated
- The `to_length` and `to_meters` are now deprecated in favor of direct use of `enforce_unit`. The docstrings as well as their execution will not print a warning. These will be removed in a future breaking release.