### PR TITLE
Add `fieldidx_oftype` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## Unreleased
 
+## [1.18.0] - 2025-09-30
+### Added
+- Added a new internal function `fieldidx_oftype` which returns the index of the first field of a type which satisfies a given comparison function.
+  - This is similar to `fieldname_oftype` but returns the index instead of the name, and is actually now used directly by `fieldname_oftype`.
+
 ## [1.17.0] - 2025-08-05
 ### Added
 - Added a new singleton type `NotFound` which is not exported and used internally for resolving properties not found in `getproperty_oftype`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BasicTypes"
 uuid = "13e19751-ccd1-416d-be0c-a6724a8caa31"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "1.17.0"
+version = "1.18.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
This PR added a new internal function `fieldidx_oftype` which returns the index of the first field of a type which satisfies a given comparison function.
  - This is similar to `fieldname_oftype` but returns the index instead of the name, and is actually now used directly by `fieldname_oftype`.