### PR TITLE
add db2lin, lin2db, λ2f and f2λ

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -15,7 +15,7 @@ permissions:
   pull-requests: write
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## Unreleased
 
+## [2.2.0] -- 2025-11-27
+
+### Added
+- Added the `db2lin`, `lin2db`, `λ2f` and `f2λ` functions we used to have scattered in different packages.
+
 ## [2.1.3] -- 2025-11-19
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BasicTypes"
 uuid = "13e19751-ccd1-416d-be0c-a6724a8caa31"
-version = "2.1.3"
+version = "2.2.0"
 authors = ["Alberto Mengali <disberd@gmail.com>", "Fabian Nawratil <git@nawratil.me>"]
 
 [deps]

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -31,7 +31,7 @@ include("constants.jl")
 export CONSTANTS
 
 include("functions.jl")
-export terminal_logger, progress_logger, basetype, sa_type
+export terminal_logger, progress_logger, basetype, sa_type, db2lin, lin2db, f2λ, λ2f
 
 include("macros.jl")
 export @define_kwargs_defaults, @add_kwargs_defaults

--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -31,7 +31,10 @@ include("constants.jl")
 export CONSTANTS
 
 include("functions.jl")
-export terminal_logger, progress_logger, basetype, sa_type, db2lin, lin2db, f2λ, λ2f
+export terminal_logger, progress_logger, basetype, sa_type
+
+include("telecom_utils.jl")
+export db2lin, lin2db, f2λ, λ2f
 
 include("macros.jl")
 export @define_kwargs_defaults, @add_kwargs_defaults

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -130,3 +130,28 @@ saf = SAField(StructArray([CompositeStruct() for i in 1:3, j in 1:2]; unwrap = T
 where the `SAField` type has a fully concrete type for it's field `sa` which would be quite complex to specify manually
 """
 sa_type(U::UnionAll, args...; kwargs...) = throw(ArgumentError("The provided eltype `$U` is not fully parametrized and would result in an abstract `StructArray` type"))
+
+
+"""
+    lin2db(x::Real)
+Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. 10 == 10dB, see https://en.wikipedia.org/wiki/Decibel)
+"""
+lin2db(x::Real) = return 10log10(x)
+
+"""
+    db2lin(x::Real)
+Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. `10 == 10dB`, see https://en.wikipedia.org/wiki/Decibel)
+"""
+db2lin(x::Real) = return exp10(x/10)
+
+"""
+    f2λ(f::Real)
+Get the wavelength (in m) starting from the frequency (in Hz)
+"""
+f2λ(f::Real) = return CONSTANTS.c/f
+
+"""
+    λ2f(λ::Real)
+Get the frequency (in Hz) starting from the wavelength (in m) 
+"""
+λ2f(λ::Real) = return CONSTANTS.c/λ

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -130,28 +130,3 @@ saf = SAField(StructArray([CompositeStruct() for i in 1:3, j in 1:2]; unwrap = T
 where the `SAField` type has a fully concrete type for it's field `sa` which would be quite complex to specify manually
 """
 sa_type(U::UnionAll, args...; kwargs...) = throw(ArgumentError("The provided eltype `$U` is not fully parametrized and would result in an abstract `StructArray` type"))
-
-
-"""
-    lin2db(x::Real)
-Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. 10 == 10dB, see https://en.wikipedia.org/wiki/Decibel)
-"""
-lin2db(x::Real) = return 10log10(x)
-
-"""
-    db2lin(x::Real)
-Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. `10 == 10dB`, see https://en.wikipedia.org/wiki/Decibel)
-"""
-db2lin(x::Real) = return exp10(x/10)
-
-"""
-    f2λ(f::Real)
-Get the wavelength (in m) starting from the frequency (in Hz)
-"""
-f2λ(f::Real) = return CONSTANTS.c/f
-
-"""
-    λ2f(λ::Real)
-Get the frequency (in Hz) starting from the wavelength (in m) 
-"""
-λ2f(λ::Real) = return CONSTANTS.c/λ

--- a/src/telecom_utils.jl
+++ b/src/telecom_utils.jl
@@ -1,0 +1,23 @@
+"""
+    lin2db(x::Real)
+Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. 10 == 10dB, see https://en.wikipedia.org/wiki/Decibel)
+"""
+lin2db(x::Real) = return 10log10(x)
+
+"""
+    db2lin(x::Real)
+Convert a number from linear to dB, assuming the input value represents a _power ratio_ (i.e. `10 == 10dB`, see https://en.wikipedia.org/wiki/Decibel)
+"""
+db2lin(x::Real) = return exp10(x/10)
+
+"""
+    f2λ(f::Real)
+Get the wavelength (in m) starting from the frequency (in Hz)
+"""
+f2λ(f::Real) = return CONSTANTS.c/f
+
+"""
+    λ2f(λ::Real)
+Get the frequency (in Hz) starting from the wavelength (in m) 
+"""
+λ2f(λ::Real) = return CONSTANTS.c/λ

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -5,14 +5,3 @@
     @test bypass_bottom(Union{}, Float64) === Float64
     @test_throws ArgumentError bypass_bottom(Union{}, Union{})
 end
-
-@testitem "dblin and f2λ" begin
-    @test lin2db(1.0) ≈ 0.0
-    @test lin2db(10.0) ≈ 10.0
-
-    @test db2lin(0.0) ≈ 1.0
-    @test db2lin(10.0) ≈ 10.0
-
-    @test f2λ(29.9792458e9) ≈ 0.01
-    @test 0.1 |> λ2f |> f2λ ≈ 0.1
-end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -5,3 +5,14 @@
     @test bypass_bottom(Union{}, Float64) === Float64
     @test_throws ArgumentError bypass_bottom(Union{}, Union{})
 end
+
+@testitem "dblin and f2λ" begin
+    @test lin2db(1.0) ≈ 0.0
+    @test lin2db(10.0) ≈ 10.0
+
+    @test db2lin(0.0) ≈ 1.0
+    @test db2lin(10.0) ≈ 10.0
+
+    @test f2λ(29.9792458e9) ≈ 0.01
+    @test 0.1 |> λ2f |> f2λ ≈ 0.1
+end

--- a/test/telecom_utils.jl
+++ b/test/telecom_utils.jl
@@ -1,0 +1,10 @@
+@testitem "telecom utils functions" begin
+    @test lin2db(1.0) ≈ 0.0
+    @test lin2db(10.0) ≈ 10.0
+
+    @test db2lin(0.0) ≈ 1.0
+    @test db2lin(10.0) ≈ 10.0
+
+    @test f2λ(29.9792458e9) ≈ 0.01
+    @test 0.1 |> λ2f |> f2λ ≈ 0.1
+end


### PR DESCRIPTION
This PR adds in this package the `db2lin`, `lin2db`, `λ2f` and `f2λ` functions that we had previously scattered elsewhere.

These are basic enough that kind of make sense here (as opposed to the link budget packet) and they could later be expanded to support unitful quantities as inputs.

I did not add already support for quantity inputs as I think it deserves a bit more discussion on the intended API so I just limited this PR to the already basic functionality we had with real numbers