### PR TITLE
Respect custom StructArray layout in `sa_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## [2.2.1] -- 2026-05-20
 ### Fixed
-- The `sa_type` function was not returing the correct type when dealing with types that define a custom StructArray layout. This is now fixed.
+- The `sa_type` function was not returning the correct type when dealing with types that define a custom StructArray layout. This is now fixed.
 
 ## [2.2.0] -- 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file contains the changelog for the BasicTypes.jl package. It follows the [
 
 ## Unreleased
 
+## [2.2.1] -- 2026-05-20
+### Fixed
+- The `sa_type` function was not returing the correct type when dealing with types that define a custom StructArray layout. This is now fixed.
+
 ## [2.2.0] -- 2025-11-27
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BasicTypes"
 uuid = "13e19751-ccd1-416d-be0c-a6724a8caa31"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Alberto Mengali <disberd@gmail.com>", "Fabian Nawratil <git@nawratil.me>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -26,9 +26,12 @@ CoordRefSystems = "0.16 - 0.19"
 Dates = "1"
 Logging = "1"
 LoggingExtras = "1.1.0"
-Meshes = "0.51 - 0.55"
+Meshes = "0.51 - 0.57"
 StaticArrays = "1.9.10"
 StructArrays = "0.7.1"
 TerminalLoggers = "0.1.7"
 Unitful = "1.22.0"
 julia = "1.11"
+
+[workspace]
+projects = ["test"]

--- a/ext/StructArraysExt.jl
+++ b/ext/StructArraysExt.jl
@@ -1,16 +1,17 @@
 module StructArraysExt
 
-using StructArrays: StructArrays, StructArray
+using StructArrays: StructArrays, StructArray, staticschema
 using BasicTypes: BasicTypes, sa_type
 
 function BasicTypes.sa_type(DT::DataType, N::Union{Int,TypeVar}; unwrap=T -> false)
     # Create the NamedTuple for the StructArray type parameter
     f = T -> unwrap(T) ? sa_type(T, N; unwrap) : Array{T,N} # Eventually unwrap like in the StructArray constructor
-    TT = Tuple{map(f, fieldtypes(DT))...}
-    NT = if DT <: Tuple
+    schema = StructArrays.staticschema(DT)
+    TT = Tuple{map(f, fieldtypes(schema))...}
+    NT = if schema <: Tuple
         TT
     else
-        NamedTuple{fieldnames(DT),TT}
+        NamedTuple{fieldnames(schema),TT}
     end
     return StructArray{DT,N,NT,Int}
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BasicTypes = "13e19751-ccd1-416d-be0c-a6724a8caa31"
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -11,3 +12,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestAllocations = "31fccf1a-3a64-44c3-87f8-a03bc812acf0"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[sources]
+BasicTypes = { path = "../" }

--- a/test/structarrays.jl
+++ b/test/structarrays.jl
@@ -59,4 +59,33 @@
     unwrap = T -> !(T <: Union{Real, Inner})
     sa = StructArray(outv; unwrap)
     @test typeof(sa) == sa_type(OuterUW, 1; unwrap)
+
+    # We test that this also gives the correct type when having a cu
+
+    @testset "Nested struct with Union field" begin
+        @kwdef struct LeafA
+            x::Float64 = rand()
+        end
+        @kwdef struct LeafB
+            y::Int = rand(1:10)
+        end
+        @kwdef struct NestedUnionField
+            val::Union{LeafA,LeafB} = rand() > 0.5 ? LeafA() : LeafB()
+            count::Int = 0
+        end
+        @kwdef struct OuterNestedUnion
+            inner::NestedUnionField = NestedUnionField()
+            flag::Bool = false
+        end
+
+        # Unwrap both outer types, but leave Union{LeafA,LeafB} as a plain Array
+        unwrap = T -> T <: Union{OuterNestedUnion,NestedUnionField}
+        data = [OuterNestedUnion() for _ in 1:15]
+        sa = StructArray(data; unwrap)
+
+        # The Union field must be stored as a plain vector with Union eltype
+        @test eltype(sa.inner.val) == Union{LeafA,LeafB}
+        # sa_type must predict exactly the same type as what the constructor produced
+        @test typeof(sa) == sa_type(OuterNestedUnion, 1; unwrap)
+    end
 end

--- a/test/structarrays.jl
+++ b/test/structarrays.jl
@@ -88,4 +88,36 @@
         # sa_type must predict exactly the same type as what the constructor produced
         @test typeof(sa) == sa_type(OuterNestedUnion, 1; unwrap)
     end
+
+    # This is a test that a custom struct with a custom staticschema is also properly handled by sa_type
+    @testset "Custom staticschema (non-standard layout)" begin
+        # Mirror the MyType example from the StructArrays advanced docs:
+        # https://juliaarrays.github.io/StructArrays.jl/stable/advanced/#Structures-with-non-standard-data-layout
+        struct MyType{T,NT<:NamedTuple}
+            data::T
+            rest::NT
+        end
+        MyType(x; kwargs...) = MyType(x, values(kwargs))
+
+        # Flatten `data` and all keyword fields of `rest` into a single schema
+        function StructArrays.staticschema(::Type{MyType{T,NamedTuple{names,types}}}) where {T,names,types}
+            return NamedTuple{(:data, names...),Base.tuple_type_cons(T, types)}
+        end
+        function StructArrays.component(m::MyType, key::Symbol)
+            return key === :data ? getfield(m, 1) : getfield(getfield(m, 2), key)
+        end
+        function StructArrays.createinstance(::Type{MyType{T,NT}}, x, args...) where {T,NT}
+            return MyType(x, NT(args))
+        end
+
+        ET = MyType{Float64,@NamedTuple{a::Int64,b::Int64}}
+        s = [MyType(i / 5, a=6 - i, b=2) for i in 1:5]
+        sa = StructArray(s)
+
+        @test typeof(sa) == sa_type(ET, 1)
+        # Spot-check that the flattened fields are directly accessible
+        @test sa.data == [i / 5 for i in 1:5]
+        @test sa.a == [5, 4, 3, 2, 1]
+        @test sa.b == fill(2, 5)
+    end
 end

--- a/test/structarrays.jl
+++ b/test/structarrays.jl
@@ -60,8 +60,8 @@
     sa = StructArray(outv; unwrap)
     @test typeof(sa) == sa_type(OuterUW, 1; unwrap)
 
-    # We test that this also gives the correct type when having a cu
-
+    # Verify that sa_type still predicts the correct StructArray type
+    # when a nested field contains a Union-typed value.
     @testset "Nested struct with Union field" begin
         @kwdef struct LeafA
             x::Float64 = rand()


### PR DESCRIPTION
This MR changed the internal of the `sa_type` function to use `StructArrays.staticschema` to correctly return the inner layout of the StructArray

### Fixed
- The `sa_type` function was not returing the correct type when dealing with types that define a custom StructArray layout. This is now fixed.